### PR TITLE
Keep ubuntu-desktop running

### DIFF
--- a/ubuntu/16.04/install.sh
+++ b/ubuntu/16.04/install.sh
@@ -125,6 +125,9 @@ cd $XORGXRDP_PATH
 make
 sudo make install
 
+#Installing xorgxrdp knocks out ubuntu-desktop from running. We need to reinstall it
+sudo apt-get install --reinstall ubuntu-desktop
+
 #
 # End XORGXRDP
 ###############################################################################


### PR DESCRIPTION
Fix a bug where ubuntu-desktop stops running and "basic mode" is lost.