### PR TITLE
Update the script for 18.04 release clean install

### DIFF
--- a/ubuntu/16.04/install.sh
+++ b/ubuntu/16.04/install.sh
@@ -11,7 +11,7 @@
 # Update our machine to the latest code if we need to.
 #
 
-if [ ! $(id -u) ] ; then
+if [ $(id -u) -ne 0 ] ; then
     echo 'This script must be run with root privileges' >&2
     exit 1
 fi

--- a/ubuntu/18.04/install.sh
+++ b/ubuntu/18.04/install.sh
@@ -11,7 +11,7 @@
 # Update our machine to the latest code if we need to.
 #
 
-if [ ! $(id -u) ] ; then
+if [ $(id -u) -ne 0 ] ; then
     echo 'This script must be run with root privileges' >&2
     exit 1
 fi
@@ -63,11 +63,6 @@ sed -i -e 's/FuseMountName=thinclient_drives/FuseMountName=shared-drives/g' /etc
 
 # Changed the allowed_users
 sed -i_orig -e 's/allowed_users=console/allowed_users=anybody/g' /etc/X11/Xwrapper.config
-
-# Enable the hv_sock module
-rmmod vmw_vsock_vmci_transport
-rmmod vsock
-modprobe hv_sock
 
 # Blacklist the vmw module
 if [ ! -e /etc/modprobe.d/blacklist_vmw_vsock_vmci_transport.conf ] ; then


### PR DESCRIPTION
Fixes a bug in the 16.04 and 18.04 script that doesnt properly check for
root at run.
Removes some unnecessary rmmod/modprobe calls that were required in
early 18.04 betas that are no longer required.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>