### PR TITLE
added requirement for dependancies for ubuntu 18.04 version

### DIFF
--- a/ubuntu/18.04/install.sh
+++ b/ubuntu/18.04/install.sh
@@ -39,7 +39,7 @@ apt install -y linux-tools-virtual${HWE}
 apt install -y linux-cloud-tools-virtual${HWE}
 
 # Install the xrdp service so we have the auto start behavior
-apt install -y xrdp
+apt install -y xrdp xserver-xorg-core xorgxrdp
 
 systemctl stop xrdp
 systemctl stop xrdp-sesman


### PR DESCRIPTION
After doing some research, I found it that it had needed two dependicies install that were there: xserver-xorg-core  & xorgxrdp.  The fix was tested on a clean install of 18.04.2 with minimal option selected.